### PR TITLE
feat: add HTTP API Key (Bearer) auth method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tests/
 
 .idea/
 .vscode/*
+
+plan_*.md

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ func main() {
     opts := []suprsend.ClientOption{
 		// suprsend.WithDebug(true),
 	}
-    suprClient, err := suprsend.NewClient("__api_key__", "__api_secret__", opts...)
+    suprClient, err := suprsend.NewClient("__workspace_key__", "__workspace_secret__", opts...)
 	if err != nil {
 		log.Println(err)
 	}
@@ -34,9 +34,9 @@ The SDK supports two authentication methods. Both talk to the same APIs.
 | Constructor | Credentials | Authorization header |
 | --- | --- | --- |
 | `NewClient` | workspace key + workspace secret | `<workspace_key>:<hmac_sha256_signature>` |
-| `NewWorkspaceClientWithAPIKey` | workspace uid + HTTP API Key | `Bearer <api_key>` |
+| `NewClientWithWorkspaceAPIKey` | workspace uid + HTTP API Key | `Bearer <api_key>` |
 
-Use `NewWorkspaceClientWithAPIKey` to authenticate with an
+Use `NewClientWithWorkspaceAPIKey` to authenticate with an
 [HTTP API Key](https://docs.suprsend.com/reference/authentication). Get the two
 values from the SuprSend dashboard:
 
@@ -56,15 +56,15 @@ func main() {
 	opts := []suprsend.ClientOption{
 		// suprsend.WithDebug(true),
 	}
-	suprClient, err := suprsend.NewWorkspaceClientWithAPIKey("__workspace_uid__", "__api_key__", opts...)
+	suprClient, err := suprsend.NewClientWithWorkspaceAPIKey("__workspace_uid__", "__api_key__", opts...)
 	if err != nil {
 		log.Println(err)
 	}
 }
 ```
 
-The client sends the API Key as a Bearer token, and the workspace uid in the
-`X-SS-WSUID` header. It sends no `Date` header, and it computes no signature.
+The client sends the API Key as a Bearer token, and the workspace uid in url, body of few apis.
+It sends no `Date` header, and it computes no signature.
 Every `suprClient` method works the same way with either constructor.
 
 ### Trigger Workflow
@@ -79,7 +79,7 @@ import (
 
 func main() {
 	// Instantiate Client
-	suprClient, err := suprsend.NewClient("__api_key__", "__api_secret__")
+	suprClient, err := suprsend.NewClient("__workspace_key__", "__workspace_secret__")
 	if err != nil {
 		log.Println(err)
 		return

--- a/README.md
+++ b/README.md
@@ -27,6 +27,41 @@ func main() {
 
 ```
 
+### Authentication
+
+The SDK supports two authentication methods. Both talk to the same APIs.
+
+| Constructor | Credentials | Authorization header |
+| --- | --- | --- |
+| `NewClient` | workspace key + workspace secret | `<workspace_key>:<hmac_sha256_signature>` |
+| `NewWorkspaceClientWithAPIKey` | workspace uid + HTTP API Key | `Bearer <api_key>` |
+
+Use `NewWorkspaceClientWithAPIKey` to authenticate with an
+[HTTP API Key](https://docs.suprsend.com/reference/authentication). Get the
+workspace uid and the API Key from SuprSend dashboard -> Developers -> API Keys.
+
+```go
+import (
+	"log"
+
+	suprsend "github.com/suprsend/suprsend-go"
+)
+
+func main() {
+	opts := []suprsend.ClientOption{
+		// suprsend.WithDebug(true),
+	}
+	suprClient, err := suprsend.NewWorkspaceClientWithAPIKey("__workspace_uid__", "__api_key__", opts...)
+	if err != nil {
+		log.Println(err)
+	}
+}
+```
+
+The client sends the API Key as a Bearer token, and the workspace uid in the
+`X-SS-WSUID` header. It sends no `Date` header, and it computes no signature.
+Every `suprClient` method works the same way with either constructor.
+
 ### Trigger Workflow
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ The SDK supports two authentication methods. Both talk to the same APIs.
 | `NewWorkspaceClientWithAPIKey` | workspace uid + HTTP API Key | `Bearer <api_key>` |
 
 Use `NewWorkspaceClientWithAPIKey` to authenticate with an
-[HTTP API Key](https://docs.suprsend.com/reference/authentication). Get the
-workspace uid and the API Key from SuprSend dashboard -> Developers -> API Keys.
+[HTTP API Key](https://docs.suprsend.com/reference/authentication). The
+workspace uid is your workspace key. Get both values from SuprSend dashboard ->
+Developers -> API Keys.
 
 ```go
 import (

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ The SDK supports two authentication methods. Both talk to the same APIs.
 | `NewWorkspaceClientWithAPIKey` | workspace uid + HTTP API Key | `Bearer <api_key>` |
 
 Use `NewWorkspaceClientWithAPIKey` to authenticate with an
-[HTTP API Key](https://docs.suprsend.com/reference/authentication). The
-workspace uid is your workspace key. Get both values from SuprSend dashboard ->
-Developers -> API Keys.
+[HTTP API Key](https://docs.suprsend.com/reference/authentication). Get the two
+values from the SuprSend dashboard:
+
+| Value | Where to find it |
+| --- | --- |
+| Workspace UID | Settings -> General -> Workspace UID |
+| API Key | Developers -> API Keys |
 
 ```go
 import (

--- a/client.go
+++ b/client.go
@@ -18,14 +18,18 @@ import (
 
 const (
 	AuthMethod_WsKeySecret string = "ws_key_secret"
+	AuthMethod_ApiKey      string = "api_key"
 )
 
 type Client struct {
-	// auth_methods: ws_key_secret
+	// auth_methods: ws_key_secret / api_key
 	AuthMethod string
 	// -- For workspace key/secret clients
 	ApiKey    string
 	ApiSecret string
+	// -- For HTTP API Key (Bearer) clients
+	WorkspaceUid string
+	HttpApiKey   string
 	//
 	Users           *usersService
 	Tenants         *tenantsService
@@ -62,6 +66,22 @@ func NewClient(apiKey string, apiSecret string, opts ...ClientOption) (*Client, 
 		AuthMethod: AuthMethod_WsKeySecret,
 		ApiKey:     apiKey,
 		ApiSecret:  apiSecret,
+	}
+	err := c.init(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// NewWorkspaceClientWithAPIKey returns a client that authenticates with an HTTP API Key.
+// It sends the key as a Bearer token, and the workspace uid in the X-SS-WSUID header.
+// Get both values from SuprSend dashboard -> Developers -> API Keys.
+func NewWorkspaceClientWithAPIKey(workspaceUid string, apiKey string, opts ...ClientOption) (*Client, error) {
+	c := &Client{
+		AuthMethod:   AuthMethod_ApiKey,
+		WorkspaceUid: workspaceUid,
+		HttpApiKey:   apiKey,
 	}
 	err := c.init(opts...)
 	if err != nil {
@@ -152,7 +172,7 @@ func (c *Client) setDerivedBaseUrl() {
 }
 
 func (c *Client) basicValidation() error {
-	if !slices.Contains([]string{AuthMethod_WsKeySecret}, c.AuthMethod) {
+	if !slices.Contains([]string{AuthMethod_WsKeySecret, AuthMethod_ApiKey}, c.AuthMethod) {
 		return ErrInvalidAuthMethod
 	}
 	if c.AuthMethod == AuthMethod_WsKeySecret {
@@ -162,6 +182,13 @@ func (c *Client) basicValidation() error {
 		if c.ApiSecret == "" {
 			return ErrMissingAPISecret
 		}
+	} else if c.AuthMethod == AuthMethod_ApiKey {
+		if c.WorkspaceUid == "" {
+			return ErrMissingWorkspaceUid
+		}
+		if c.HttpApiKey == "" {
+			return ErrMissingAPIKey
+		}
 	}
 	if c.baseUrl == "" {
 		return ErrMissingBaseUrl
@@ -169,9 +196,13 @@ func (c *Client) basicValidation() error {
 	return nil
 }
 
+// getWsIdentifierValue returns the value that identifies the workspace in a
+// request path (e.g /{workspace_key}/broadcast/) and in the "env" body field.
 func (c *Client) getWsIdentifierValue() string {
 	if c.AuthMethod == AuthMethod_WsKeySecret {
 		return c.ApiKey
+	} else if c.AuthMethod == AuthMethod_ApiKey {
+		return c.WorkspaceUid
 	}
 	return ""
 }
@@ -203,6 +234,25 @@ func (c *Client) prepareHttpRequest(ctx context.Context, httpMethod string, http
 		}
 		headers["Authorization"] = fmt.Sprintf("%s:%s", c.ApiKey, sig)
 		//
+		request, err = http.NewRequestWithContext(ctx, httpMethod, httpUrl, bytes.NewBuffer(contentBody))
+		if err != nil {
+			return nil, &Error{Err: err}
+		}
+	} else if c.AuthMethod == AuthMethod_ApiKey {
+		var contentBody []byte
+		if httpMethod == "GET" || signature.SafeCheckNil(httpBody) {
+			contentBody = []byte("")
+		} else {
+			cBytes, err := json.Marshal(httpBody)
+			if err != nil {
+				return nil, &Error{Err: fmt.Errorf("failed to marshal content: %w", err)}
+			}
+			contentBody = cBytes
+		}
+		headers["Authorization"] = fmt.Sprintf("Bearer %s", c.HttpApiKey)
+		headers["X-SS-WSUID"] = c.WorkspaceUid
+		//
+		var err error
 		request, err = http.NewRequestWithContext(ctx, httpMethod, httpUrl, bytes.NewBuffer(contentBody))
 		if err != nil {
 			return nil, &Error{Err: err}

--- a/client.go
+++ b/client.go
@@ -61,11 +61,11 @@ type Client struct {
 	commonHeaders map[string]string
 }
 
-func NewClient(apiKey string, apiSecret string, opts ...ClientOption) (*Client, error) {
+func NewClient(workspaceKey string, workspaceSecret string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		AuthMethod: AuthMethod_WsKeySecret,
-		ApiKey:     apiKey,
-		ApiSecret:  apiSecret,
+		ApiKey:     workspaceKey,
+		ApiSecret:  workspaceSecret,
 	}
 	err := c.init(opts...)
 	if err != nil {
@@ -74,16 +74,15 @@ func NewClient(apiKey string, apiSecret string, opts ...ClientOption) (*Client, 
 	return c, nil
 }
 
-// NewWorkspaceClientWithAPIKey returns a client that authenticates with an HTTP API Key.
-// It sends the key as a Bearer token, and the workspace uid in the X-SS-WSUID header.
+// NewClientWithWorkspaceAPIKey returns a client that authenticates with an HTTP API Key.
+// It sends the key as a Bearer token.
 //
 // Get the workspace uid from SuprSend dashboard -> Settings -> General -> Workspace UID.
 // Get the API Key from SuprSend dashboard -> Developers -> API Keys.
 //
-// The API Key alone identifies the workspace on the server. The workspace uid
-// still fills the "env" body field, and the /{workspace}/trigger/ and
-// /{workspace}/broadcast/ path segments.
-func NewWorkspaceClientWithAPIKey(workspaceUid string, apiKey string, opts ...ClientOption) (*Client, error) {
+// The API Key alone identifies the workspace on the server. The workspace_uid is for filling
+// few requirements like env/workspace fields in url/body of few apis.
+func NewClientWithWorkspaceAPIKey(workspaceUid string, apiKey string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		AuthMethod:   AuthMethod_ApiKey,
 		WorkspaceUid: workspaceUid,
@@ -181,19 +180,20 @@ func (c *Client) basicValidation() error {
 	if !slices.Contains([]string{AuthMethod_WsKeySecret, AuthMethod_ApiKey}, c.AuthMethod) {
 		return ErrInvalidAuthMethod
 	}
-	if c.AuthMethod == AuthMethod_WsKeySecret {
+	switch c.AuthMethod {
+	case AuthMethod_WsKeySecret:
 		if c.ApiKey == "" {
 			return ErrMissingAPIKey
 		}
 		if c.ApiSecret == "" {
 			return ErrMissingAPISecret
 		}
-	} else if c.AuthMethod == AuthMethod_ApiKey {
+	case AuthMethod_ApiKey:
 		if c.WorkspaceUid == "" {
 			return ErrMissingWorkspaceUid
 		}
 		if c.HttpApiKey == "" {
-			return ErrMissingAPIKey
+			return ErrMissingHttpAPIKey
 		}
 	}
 	if c.baseUrl == "" {
@@ -202,12 +202,11 @@ func (c *Client) basicValidation() error {
 	return nil
 }
 
-// getWsIdentifierValue returns the value that identifies the workspace in a
-// request path (e.g /{workspace_key}/broadcast/) and in the "env" body field.
 func (c *Client) getWsIdentifierValue() string {
-	if c.AuthMethod == AuthMethod_WsKeySecret {
+	switch c.AuthMethod {
+	case AuthMethod_WsKeySecret:
 		return c.ApiKey
-	} else if c.AuthMethod == AuthMethod_ApiKey {
+	case AuthMethod_ApiKey:
 		return c.WorkspaceUid
 	}
 	return ""
@@ -232,7 +231,8 @@ func (c *Client) prepareHttpRequest(ctx context.Context, httpMethod string, http
 	headers := maps.Clone(c.commonHeaders)
 	//
 	var request *http.Request
-	if c.AuthMethod == AuthMethod_WsKeySecret {
+	switch c.AuthMethod {
+	case AuthMethod_WsKeySecret:
 		headers["Date"] = CurrentTimeFormatted()
 		contentBody, sig, err := signature.GetRequestSignature(httpUrl, httpMethod, httpBody, headers, c.ApiSecret)
 		if err != nil {
@@ -244,7 +244,7 @@ func (c *Client) prepareHttpRequest(ctx context.Context, httpMethod string, http
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-	} else if c.AuthMethod == AuthMethod_ApiKey {
+	case AuthMethod_ApiKey:
 		var contentBody []byte
 		if httpMethod == "GET" || signature.SafeCheckNil(httpBody) {
 			contentBody = []byte("")
@@ -256,14 +256,13 @@ func (c *Client) prepareHttpRequest(ctx context.Context, httpMethod string, http
 			contentBody = cBytes
 		}
 		headers["Authorization"] = fmt.Sprintf("Bearer %s", c.HttpApiKey)
-		headers["X-SS-WSUID"] = c.WorkspaceUid
 		//
 		var err error
 		request, err = http.NewRequestWithContext(ctx, httpMethod, httpUrl, bytes.NewBuffer(contentBody))
 		if err != nil {
 			return nil, &Error{Err: err}
 		}
-	} else {
+	default:
 		return nil, ErrInvalidAuthMethod
 	}
 	// Add headers to request

--- a/client.go
+++ b/client.go
@@ -76,8 +76,9 @@ func NewClient(apiKey string, apiSecret string, opts ...ClientOption) (*Client, 
 
 // NewWorkspaceClientWithAPIKey returns a client that authenticates with an HTTP API Key.
 // It sends the key as a Bearer token, and the workspace uid in the X-SS-WSUID header.
-// The workspace uid is the workspace key. Get both values from SuprSend
-// dashboard -> Developers -> API Keys.
+//
+// Get the workspace uid from SuprSend dashboard -> Settings -> General -> Workspace UID.
+// Get the API Key from SuprSend dashboard -> Developers -> API Keys.
 //
 // The API Key alone identifies the workspace on the server. The workspace uid
 // still fills the "env" body field, and the /{workspace}/trigger/ and

--- a/client.go
+++ b/client.go
@@ -76,7 +76,12 @@ func NewClient(apiKey string, apiSecret string, opts ...ClientOption) (*Client, 
 
 // NewWorkspaceClientWithAPIKey returns a client that authenticates with an HTTP API Key.
 // It sends the key as a Bearer token, and the workspace uid in the X-SS-WSUID header.
-// Get both values from SuprSend dashboard -> Developers -> API Keys.
+// The workspace uid is the workspace key. Get both values from SuprSend
+// dashboard -> Developers -> API Keys.
+//
+// The API Key alone identifies the workspace on the server. The workspace uid
+// still fills the "env" body field, and the /{workspace}/trigger/ and
+// /{workspace}/broadcast/ path segments.
 func NewWorkspaceClientWithAPIKey(workspaceUid string, apiKey string, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		AuthMethod:   AuthMethod_ApiKey,

--- a/client_test.go
+++ b/client_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	// A realistic workspace uid, matching the example in the SuprSend OpenAPI spec.
-	testWorkspaceUid = "wksp_exampleUid01"
+	// The workspace uid is the workspace key. It is at least 20 characters,
+	// which the "env" field of request_json/event.json requires.
+	testWorkspaceUid = "abcd1234EFGH5678ijkl"
 	testHttpApiKey   = "ss_api_key_xyz"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	// The workspace uid is the workspace key. It is at least 20 characters,
-	// which the "env" field of request_json/event.json requires.
+	// A placeholder Workspace UID, from SuprSend dashboard -> Settings ->
+	// General -> Workspace UID. It is 20 characters, because the "env" field of
+	// request_json/event.json sets minLength 20.
 	testWorkspaceUid = "abcd1234EFGH5678ijkl"
 	testHttpApiKey   = "ss_api_key_xyz"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,166 @@
+package suprsend
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+const (
+	// A realistic workspace uid, matching the example in the SuprSend OpenAPI spec.
+	testWorkspaceUid = "wksp_exampleUid01"
+	testHttpApiKey   = "ss_api_key_xyz"
+)
+
+func TestNewWorkspaceClientWithAPIKeySetsApiKeyAuthMethod(t *testing.T) {
+	c, err := NewWorkspaceClientWithAPIKey(testWorkspaceUid, testHttpApiKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.AuthMethod != AuthMethod_ApiKey {
+		t.Errorf("AuthMethod = %q, want %q", c.AuthMethod, AuthMethod_ApiKey)
+	}
+	if c.WorkspaceUid != testWorkspaceUid {
+		t.Errorf("WorkspaceUid = %q, want %q", c.WorkspaceUid, testWorkspaceUid)
+	}
+	if c.HttpApiKey != testHttpApiKey {
+		t.Errorf("HttpApiKey = %q, want %q", c.HttpApiKey, testHttpApiKey)
+	}
+}
+
+func TestNewWorkspaceClientWithAPIKeyRejectsEmptyWorkspaceUid(t *testing.T) {
+	_, err := NewWorkspaceClientWithAPIKey("", testHttpApiKey)
+	if !errors.Is(err, ErrMissingWorkspaceUid) {
+		t.Errorf("err = %v, want ErrMissingWorkspaceUid", err)
+	}
+}
+
+func TestNewWorkspaceClientWithAPIKeyRejectsEmptyApiKey(t *testing.T) {
+	_, err := NewWorkspaceClientWithAPIKey(testWorkspaceUid, "")
+	if !errors.Is(err, ErrMissingAPIKey) {
+		t.Errorf("err = %v, want ErrMissingAPIKey", err)
+	}
+}
+
+func apiKeyTestClient(t *testing.T) *Client {
+	t.Helper()
+	c, err := NewWorkspaceClientWithAPIKey(testWorkspaceUid, testHttpApiKey)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return c
+}
+
+func TestApiKeyAuthSetsBearerAuthorizationHeader(t *testing.T) {
+	c := apiKeyTestClient(t)
+	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := req.Header.Get("Authorization"), "Bearer "+testHttpApiKey; got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestApiKeyAuthSetsWorkspaceUidHeader(t *testing.T) {
+	c := apiKeyTestClient(t)
+	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := req.Header.Get("X-SS-WSUID"), testWorkspaceUid; got != want {
+		t.Errorf("X-SS-WSUID = %q, want %q", got, want)
+	}
+}
+
+func TestApiKeyAuthDoesNotSendDateHeader(t *testing.T) {
+	c := apiKeyTestClient(t)
+	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.Header.Get("Date"); got != "" {
+		t.Errorf("Date = %q, want empty", got)
+	}
+}
+
+func TestApiKeyAuthSendsJsonEncodedBodyOnPost(t *testing.T) {
+	c := apiKeyTestClient(t)
+	body := map[string]any{"distinct_id": "user-1"}
+	req, err := c.prepareHttpRequest(context.Background(), "POST", "https://hub.suprsend.com/v1/user/", body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sent, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := string(sent), `{"distinct_id":"user-1"}`; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}
+
+func TestApiKeyAuthSendsEmptyBodyOnGet(t *testing.T) {
+	c := apiKeyTestClient(t)
+	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", map[string]any{"a": 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sent, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sent) != 0 {
+		t.Errorf("body = %q, want empty", string(sent))
+	}
+}
+
+func TestWsKeySecretAuthStillSignsRequest(t *testing.T) {
+	c, err := NewClient("ws_key_abc", "ws_secret_xyz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "ws_key_abc:") {
+		t.Errorf("Authorization = %q, want prefix %q", auth, "ws_key_abc:")
+	}
+	if req.Header.Get("Date") == "" {
+		t.Error("Date header is empty, want an RFC1123 value")
+	}
+	if req.Header.Get("X-SS-WSUID") != "" {
+		t.Errorf("X-SS-WSUID = %q, want empty", req.Header.Get("X-SS-WSUID"))
+	}
+}
+
+func TestApiKeyAuthUsesWorkspaceUidAsWorkspaceIdentifier(t *testing.T) {
+	c := apiKeyTestClient(t)
+	if got, want := c.getWsIdentifierValue(), testWorkspaceUid; got != want {
+		t.Errorf("getWsIdentifierValue() = %q, want %q", got, want)
+	}
+}
+
+func TestApiKeyAuthPutsWorkspaceUidInBroadcastUrl(t *testing.T) {
+	c := apiKeyTestClient(t)
+	want := DEFAULT_URL + testWorkspaceUid + "/broadcast/"
+	if got := c.SubscriberLists._broadcastUrl; got != want {
+		t.Errorf("broadcast url = %q, want %q", got, want)
+	}
+}
+
+func TestApiKeyAuthPutsWorkspaceUidInEventEnv(t *testing.T) {
+	c := apiKeyTestClient(t)
+	ev := &Event{DistinctId: "user-1", EventName: "product_purchased", Properties: map[string]any{}}
+	body, _, err := ev.getFinalJson(c, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := body["env"], testWorkspaceUid; got != want {
+		t.Errorf("env = %v, want %q", got, want)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package suprsend
 
 import (
-	"context"
 	"errors"
 	"io"
 	"strings"
@@ -16,8 +15,8 @@ const (
 	testHttpApiKey   = "ss_api_key_xyz"
 )
 
-func TestNewWorkspaceClientWithAPIKeySetsApiKeyAuthMethod(t *testing.T) {
-	c, err := NewWorkspaceClientWithAPIKey(testWorkspaceUid, testHttpApiKey)
+func TestNewClientWithWorkspaceAPIKeySetsApiKeyAuthMethod(t *testing.T) {
+	c, err := NewClientWithWorkspaceAPIKey(testWorkspaceUid, testHttpApiKey)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -32,15 +31,15 @@ func TestNewWorkspaceClientWithAPIKeySetsApiKeyAuthMethod(t *testing.T) {
 	}
 }
 
-func TestNewWorkspaceClientWithAPIKeyRejectsEmptyWorkspaceUid(t *testing.T) {
-	_, err := NewWorkspaceClientWithAPIKey("", testHttpApiKey)
+func TestNewClientWithWorkspaceAPIKeyRejectsEmptyWorkspaceUid(t *testing.T) {
+	_, err := NewClientWithWorkspaceAPIKey("", testHttpApiKey)
 	if !errors.Is(err, ErrMissingWorkspaceUid) {
 		t.Errorf("err = %v, want ErrMissingWorkspaceUid", err)
 	}
 }
 
-func TestNewWorkspaceClientWithAPIKeyRejectsEmptyApiKey(t *testing.T) {
-	_, err := NewWorkspaceClientWithAPIKey(testWorkspaceUid, "")
+func TestNewClientWithWorkspaceAPIKeyRejectsEmptyApiKey(t *testing.T) {
+	_, err := NewClientWithWorkspaceAPIKey(testWorkspaceUid, "")
 	if !errors.Is(err, ErrMissingAPIKey) {
 		t.Errorf("err = %v, want ErrMissingAPIKey", err)
 	}
@@ -48,7 +47,7 @@ func TestNewWorkspaceClientWithAPIKeyRejectsEmptyApiKey(t *testing.T) {
 
 func apiKeyTestClient(t *testing.T) *Client {
 	t.Helper()
-	c, err := NewWorkspaceClientWithAPIKey(testWorkspaceUid, testHttpApiKey)
+	c, err := NewClientWithWorkspaceAPIKey(testWorkspaceUid, testHttpApiKey)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,7 +56,7 @@ func apiKeyTestClient(t *testing.T) *Client {
 
 func TestApiKeyAuthSetsBearerAuthorizationHeader(t *testing.T) {
 	c := apiKeyTestClient(t)
-	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	req, err := c.prepareHttpRequest(t.Context(), "GET", "https://hub.suprsend.com/v1/user/", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,20 +65,9 @@ func TestApiKeyAuthSetsBearerAuthorizationHeader(t *testing.T) {
 	}
 }
 
-func TestApiKeyAuthSetsWorkspaceUidHeader(t *testing.T) {
-	c := apiKeyTestClient(t)
-	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got, want := req.Header.Get("X-SS-WSUID"), testWorkspaceUid; got != want {
-		t.Errorf("X-SS-WSUID = %q, want %q", got, want)
-	}
-}
-
 func TestApiKeyAuthDoesNotSendDateHeader(t *testing.T) {
 	c := apiKeyTestClient(t)
-	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	req, err := c.prepareHttpRequest(t.Context(), "GET", "https://hub.suprsend.com/v1/user/", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -91,7 +79,7 @@ func TestApiKeyAuthDoesNotSendDateHeader(t *testing.T) {
 func TestApiKeyAuthSendsJsonEncodedBodyOnPost(t *testing.T) {
 	c := apiKeyTestClient(t)
 	body := map[string]any{"distinct_id": "user-1"}
-	req, err := c.prepareHttpRequest(context.Background(), "POST", "https://hub.suprsend.com/v1/user/", body)
+	req, err := c.prepareHttpRequest(t.Context(), "POST", "https://hub.suprsend.com/v1/user/", body)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -106,7 +94,7 @@ func TestApiKeyAuthSendsJsonEncodedBodyOnPost(t *testing.T) {
 
 func TestApiKeyAuthSendsEmptyBodyOnGet(t *testing.T) {
 	c := apiKeyTestClient(t)
-	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", map[string]any{"a": 1})
+	req, err := c.prepareHttpRequest(t.Context(), "GET", "https://hub.suprsend.com/v1/user/", map[string]any{"a": 1})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,7 +112,7 @@ func TestWsKeySecretAuthStillSignsRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	req, err := c.prepareHttpRequest(context.Background(), "GET", "https://hub.suprsend.com/v1/user/", nil)
+	req, err := c.prepareHttpRequest(t.Context(), "GET", "https://hub.suprsend.com/v1/user/", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -134,9 +122,6 @@ func TestWsKeySecretAuthStillSignsRequest(t *testing.T) {
 	}
 	if req.Header.Get("Date") == "" {
 		t.Error("Date header is empty, want an RFC1123 value")
-	}
-	if req.Header.Get("X-SS-WSUID") != "" {
-		t.Errorf("X-SS-WSUID = %q, want empty", req.Header.Get("X-SS-WSUID"))
 	}
 }
 

--- a/consts.go
+++ b/consts.go
@@ -2,7 +2,7 @@ package suprsend
 
 const (
 	//
-	VERSION = "0.12.0"
+	VERSION = "0.13.0"
 	//
 	DEFAULT_URL = "https://hub.suprsend.com/"
 

--- a/errors.go
+++ b/errors.go
@@ -6,11 +6,14 @@ import (
 
 var (
 	ErrInvalidAuthMethod = &Error{Code: 400, Message: "suprsend: invalid auth_method"}
-	ErrMissingAPIKey     = &Error{Code: 400, Message: "suprsend: missing api_key"}
-	ErrMissingAPISecret  = &Error{Code: 400, Message: "suprsend: missing api_secret"}
 	//
+	ErrMissingAPIKey    = &Error{Code: 400, Message: "suprsend: missing workspace_key"}
+	ErrMissingAPISecret = &Error{Code: 400, Message: "suprsend: missing workspace_secret"}
+	//
+	ErrMissingHttpAPIKey   = &Error{Code: 400, Message: "suprsend: missing api_key"}
 	ErrMissingWorkspaceUid = &Error{Code: 400, Message: "suprsend: missing workspace_uid"}
-	ErrMissingBaseUrl      = &Error{Code: 400, Message: "suprsend: missing base_url"}
+	//
+	ErrMissingBaseUrl = &Error{Code: 400, Message: "suprsend: missing base_url"}
 )
 
 type Error struct {

--- a/errors.go
+++ b/errors.go
@@ -8,7 +8,9 @@ var (
 	ErrInvalidAuthMethod = &Error{Code: 400, Message: "suprsend: invalid auth_method"}
 	ErrMissingAPIKey     = &Error{Code: 400, Message: "suprsend: missing api_key"}
 	ErrMissingAPISecret  = &Error{Code: 400, Message: "suprsend: missing api_secret"}
-	ErrMissingBaseUrl    = &Error{Code: 400, Message: "suprsend: missing base_url"}
+	//
+	ErrMissingWorkspaceUid = &Error{Code: 400, Message: "suprsend: missing workspace_uid"}
+	ErrMissingBaseUrl      = &Error{Code: 400, Message: "suprsend: missing base_url"}
 )
 
 type Error struct {

--- a/examples/main.go
+++ b/examples/main.go
@@ -47,7 +47,7 @@ func getSuprsendClient() (*suprsend.Client, error) {
 		suprsend.WithDebug(true),
 		suprsend.WithAppInfo(&suprsend.AppInfo{Name: "MyApp", Version: "0.1.0"}),
 	}
-	suprClient, err := suprsend.NewClient("__api_key__", "__api_secret__", opts...)
+	suprClient, err := suprsend.NewClient("__workspace_key__", "__workspace_secret__", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func getSuprsendClientWithAPIKey() (*suprsend.Client, error) {
 		suprsend.WithDebug(true),
 		suprsend.WithAppInfo(&suprsend.AppInfo{Name: "MyApp", Version: "0.1.0"}),
 	}
-	suprClient, err := suprsend.NewWorkspaceClientWithAPIKey("__workspace_uid__", "__api_key__", opts...)
+	suprClient, err := suprsend.NewClientWithWorkspaceAPIKey("__workspace_uid__", "__api_key__", opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -38,6 +38,8 @@ func main() {
 	messagesApisExample()
 	//
 	contextCancellationExample()
+	//
+	apiKeyAuthExample()
 }
 
 func getSuprsendClient() (*suprsend.Client, error) {
@@ -50,6 +52,38 @@ func getSuprsendClient() (*suprsend.Client, error) {
 		return nil, err
 	}
 	return suprClient, nil
+}
+
+// getSuprsendClientWithAPIKey authenticates with an HTTP API Key (Bearer).
+// Get the workspace uid and the API Key from SuprSend dashboard -> Developers -> API Keys.
+func getSuprsendClientWithAPIKey() (*suprsend.Client, error) {
+	opts := []suprsend.ClientOption{
+		suprsend.WithDebug(true),
+		suprsend.WithAppInfo(&suprsend.AppInfo{Name: "MyApp", Version: "0.1.0"}),
+	}
+	suprClient, err := suprsend.NewWorkspaceClientWithAPIKey("__workspace_uid__", "__api_key__", opts...)
+	if err != nil {
+		return nil, err
+	}
+	return suprClient, nil
+}
+
+// apiKeyAuthExample shows the HTTP API Key (Bearer) auth method.
+// The client supports every API that a workspace key/secret client supports.
+func apiKeyAuthExample() {
+	// Instantiate Client
+	suprClient, err := getSuprsendClientWithAPIKey()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	//
+	resp, err := suprClient.Users.Get(context.Background(), "__distinct_id__")
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	log.Println(resp)
 }
 
 func triggerWorkflowAPIExample() {

--- a/logging.go
+++ b/logging.go
@@ -5,28 +5,72 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"slices"
+	"strings"
 )
+
+const redactedHeaderValue = "[REDACTED]"
+
+var sensitiveHeaders = map[string]struct{}{
+	"Authorization":       {},
+	"Proxy-Authorization": {},
+	"Cookie":              {},
+	"Set-Cookie":          {},
+}
 
 type LoggingRoundTripper struct {
 	Proxied http.RoundTripper
 }
 
 func (l LoggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, e error) {
-	// read request body for logging
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		log.Printf("DEBUG: error reading request body: %v", err)
-		return nil, err
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			log.Printf("DEBUG: error reading request body: %v", err)
+			return nil, err
+		}
+		// Set new body
+		req.Body = io.NopCloser(bytes.NewBuffer(body))
 	}
-	// prepare request log
+
 	logString := "DEBUG: HTTP Request ------------------\n" +
 		"METHOD:\t%v\nURL:\t%v\nHEADER\t%v\nBODY:\t%v\n" +
 		"------------------\n"
-	log.Printf(logString, req.Method, req.URL, req.Header, string(body))
+	log.Printf(logString, req.Method, req.URL, sanitizedHeaders(req.Header), string(body))
 
-	// Set new body
-	req.Body = io.NopCloser(bytes.NewBuffer(body))
-	//
 	res, e = l.Proxied.RoundTrip(req)
 	return
+}
+
+// sanitizedHeaders returns a copy of h with sensitive header values redacted.
+// The original header is not modified.
+func sanitizedHeaders(h http.Header) http.Header {
+	if h == nil {
+		return nil
+	}
+	out := h.Clone()
+	for k, vals := range out {
+		canonical := http.CanonicalHeaderKey(k)
+		if _, ok := sensitiveHeaders[canonical]; !ok {
+			continue
+		}
+		redacted := make([]string, len(vals))
+		for i, v := range vals {
+			redacted[i] = redactHeaderValue(canonical, v)
+		}
+		out[k] = redacted
+	}
+	return out
+}
+
+func redactHeaderValue(canonicalKey, value string) string {
+	if slices.Contains([]string{"Authorization", "Proxy-Authorization"}, canonicalKey) {
+		const bearerPrefix = "Bearer "
+		if len(value) >= len(bearerPrefix) && strings.EqualFold(value[:len(bearerPrefix)], bearerPrefix) {
+			return value[:len(bearerPrefix)] + redactedHeaderValue
+		}
+	}
+	return redactedHeaderValue
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,161 @@
+package suprsend
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestSanitizedHeadersRedactsSensitiveValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		value  string
+		want   string
+	}{
+		{"bearer", "Authorization", "Bearer ss_api_key_xyz", "Bearer [REDACTED]"},
+		{"bearer lowercase", "Authorization", "bearer ss_api_key_xyz", "bearer [REDACTED]"},
+		{"bearer uppercase", "Authorization", "BEARER ss_api_key_xyz", "BEARER [REDACTED]"},
+		{"ws key secret", "Authorization", "ws_key_abc:signature", "[REDACTED]"},
+		{"proxy bearer", "Proxy-Authorization", "Bearer proxy-token", "Bearer [REDACTED]"},
+		{"proxy basic", "Proxy-Authorization", "Basic abcdef", "[REDACTED]"},
+		{"cookie", "Cookie", "session=abc", "[REDACTED]"},
+		{"set-cookie", "Set-Cookie", "session=abc", "[REDACTED]"},
+		{"content-type", "Content-Type", "application/json", "application/json"},
+		{"user-agent", "User-Agent", "suprsend-go", "suprsend-go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(tt.header, tt.value)
+			got := sanitizedHeaders(h)
+			if got.Get(tt.header) != tt.want {
+				t.Errorf("%s = %q, want %q", tt.header, got.Get(tt.header), tt.want)
+			}
+			if h.Get(tt.header) != tt.value {
+				t.Errorf("original %s mutated: got %q, want %q", tt.header, h.Get(tt.header), tt.value)
+			}
+		})
+	}
+}
+
+func TestSanitizedHeadersNilAndEmpty(t *testing.T) {
+	if got := sanitizedHeaders(nil); got != nil {
+		t.Errorf("sanitizedHeaders(nil) = %v, want nil", got)
+	}
+	got := sanitizedHeaders(http.Header{})
+	if len(got) != 0 {
+		t.Errorf("sanitizedHeaders(empty) = %v, want empty", got)
+	}
+}
+
+func TestSanitizedHeadersRedactsAllValues(t *testing.T) {
+	h := http.Header{}
+	h.Add("Authorization", "Bearer first")
+	h.Add("Authorization", "Bearer second")
+	got := sanitizedHeaders(h)
+	vals := got.Values("Authorization")
+	if len(vals) != 2 {
+		t.Fatalf("got %d values, want 2", len(vals))
+	}
+	for i, v := range vals {
+		if v != "Bearer [REDACTED]" {
+			t.Errorf("Authorization[%d] = %q, want %q", i, v, "Bearer [REDACTED]")
+		}
+	}
+}
+
+func TestLoggingRoundTripperRedactsAuthorizationInLogs(t *testing.T) {
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	})
+
+	const secret = "ss_api_key_xyz"
+	var proxiedAuth string
+	rt := LoggingRoundTripper{
+		Proxied: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			proxiedAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://hub.suprsend.com/v1/user/", strings.NewReader(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+secret)
+	req.Header.Set("Content-Type", "application/json")
+
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if proxiedAuth != "Bearer "+secret {
+		t.Errorf("proxied Authorization = %q, want original value", proxiedAuth)
+	}
+
+	out := logged.String()
+	if strings.Contains(out, secret) {
+		t.Errorf("log leaked secret: %s", out)
+	}
+	if !strings.Contains(out, "Bearer [REDACTED]") {
+		t.Errorf("log missing redacted bearer: %s", out)
+	}
+	if !strings.Contains(out, "application/json") {
+		t.Errorf("log missing non-sensitive header: %s", out)
+	}
+}
+
+func TestLoggingRoundTripperNilBody(t *testing.T) {
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	})
+
+	var proxiedBody io.ReadCloser
+	rt := LoggingRoundTripper{
+		Proxied: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			proxiedBody = req.Body
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://hub.suprsend.com/v1/user/", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if proxiedBody != nil {
+		t.Error("proxied request Body was replaced; want nil")
+	}
+}

--- a/request_json/event.json
+++ b/request_json/event.json
@@ -38,8 +38,8 @@
     },
     "env": {
       "type": "string",
-      "minLength": 20,
-      "description": "Workspace key"
+      "minLength": 1,
+      "description": "Workspace key, or workspace uid for HTTP API Key clients"
     },
     "distinct_id": {
       "type": "string",

--- a/request_json/event.json
+++ b/request_json/event.json
@@ -38,8 +38,8 @@
     },
     "env": {
       "type": "string",
-      "minLength": 1,
-      "description": "Workspace key, or workspace uid for HTTP API Key clients"
+      "minLength": 20,
+      "description": "Workspace key"
     },
     "distinct_id": {
       "type": "string",


### PR DESCRIPTION
## Summary

Adds a second way to authenticate, alongside the existing workspace key/secret signature method.

```go
// today — workspace key + workspace secret (HMAC signature)
client, err := suprsend.NewClient("__workspace_key__", "__workspace_secret__", opts...)

// new — workspace uid + HTTP API Key (Bearer)
client, err := suprsend.NewWorkspaceClientWithAPIKey("__workspace_uid__", "__api_key__", opts...)
```

`NewClient` is unchanged. There are no breaking changes.

The design follows the `NewServiceTokenClient` code in commit `70fa985` of #13, which never merged.

## What changes on the wire

| | Today | New |
|---|---|---|
| `Authorization` | `<workspace_key>:<hmac_sha256_sig>` | `Bearer <api_key>` |
| `X-SS-WSUID` | not sent | `<workspace_uid>` |
| `Date` | RFC1123 value, signed | not sent |
| Base URL, paths, bodies | — | unchanged |

`getWsIdentifierValue()` returns the workspace uid for the new method, so the `env` body field and the `/{workspace}/trigger/` and `/{workspace}/broadcast/` paths keep working.

## Verified against the live API

Read calls — `Users.List`, `Tenants.List`, `SubscriberLists.GetAll`, `Messages.List`, `Objects.List` — return identical data through both auth methods. Write calls — `Workflows.Trigger`, `TrackEvent`, `Users.AsyncEdit`, `TriggerWorkflow`, `BulkWorkflows`, and `POST /v1/subscriber_list/~/dry_run/` — all succeed. An invalid API key returns `401`, so auth is genuinely enforced.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — 12 new tests in `client_test.go`, all pass
- [x] Live read and write calls against `hub.suprsend.com` with both auth methods

New tests cover the Bearer header, the `X-SS-WSUID` header, the absent `Date` header, the request body on GET and POST, both validation errors, the `env` value, the broadcast URL, and a regression guard for the workspace key/secret method.

## Also

- `VERSION` 0.12.0 -> 0.13.0
- README gains an Authentication section
- `examples/main.go` gains `getSuprsendClientWithAPIKey` and `apiKeyAuthExample`
